### PR TITLE
DX-174 | @rhigdon | aria-hidden on decorative images

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -21,12 +21,12 @@ you will need a copy of your AudioEye Entitlement Token. This token is available
 
 1. Log in to the [AudioEye Customer Portal](https://portal.audioeye.com/). 
 2. Click on the account menu in the top right and select the *My Account* menu item.
-   ![My Account Selection](/my-account.png)
+   <img src="/my-account.png" aria-hidden="true" />
 3. Scroll down to the *Testing SDK Entitlement Token* section.
 4. If not created yet, click the *Generate Entitlement Token* button to create a token for your account.
-   ![Generate Entitlement Token](/generate-entitlement-token.png)
+   <img src="/generate-entitlement-token.png" aria-hidden="true" />
 5. Once complete click on the *Copy Entitlement Token* button to copy the key to your clipboard.
-   ![Copy Entitlement Token](/copy-entitlement-token.png)
+   <img src="/copy-entitlement-token.png" aria-hidden="true" />
 
 This key can now be used to download the AudioEye Testing SDK packages. We will refer to this key as
 `AUDIOEYE_ENTITLEMENT_TOKEN` in the rest of this document.


### PR DESCRIPTION
## Summary

These are image alt text updates to address issues found via an [A11y audit](https://docs.google.com/spreadsheets/d/1O8p2-kczyDs1AJaZ6H0QkWxS-D5d_Sb_OizZ85Z6WXE/edit#gid=0) of our SDK documentation. We're hiding several images deemed as decorative and updating copy to make two of them more descriptive.