### PR TITLE
NOJIRA | @jwlsinx | Remove `async` option from audioeye script

### DIFF
--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -53,14 +53,16 @@ npx aetest scan < example_inputs/component.html -c
 ### Option Flags for Scanning
 
 ```
-  -c, --component                Run in component mode (create a document and inject the HTML)
-  -p, --print-test-list          Print the list of tests that will be run
-  -d, --debug                    Internal Use only (Don't build off of this!)
-  -t, --output-type <file_type>  Define the file type of the output (html, json or csv) (default: "html")
-  -o, --output <filename>        Define the file path for test results output, default is ./aetest_results.<file_type>
-  -s, --stdout                   Output full results to stdout as well as a file, this will replace the summary output normally shown on stdout
-  -m, --timeout <seconds>        Set the timeout for DOM rendering in seconds, default is 5 (default: "5")
-  -h, --help                     display help for command
+  -c, --component                             Run in component mode (create a document and inject the HTML)
+  -p, --print-test-list                       Print the list of tests that will be run
+  -d, --debug                                 Internal Use only (Don't build off of this!)
+  -f, --format <file_type>                    Define the file type of the output (html, json or csv) (default: "html")
+  -o, --output <filename>                     Define the file path for test results output, default is ./aetest_results.<file_type>
+  -s, --stdout                                Output full results to stdout as well as a file, this will replace the summary output normally shown on stdout
+  -t, --timeout <seconds>                     Set the timeout for DOM rendering in seconds, default is 5 (default: "5")
+  -v, --viewport-dimensions <width>x<height>  Set the viewport dimensions for the browser (width and height separated by "x")
+  -m, --mobile                                Set the viewport to a mobile device. Customize dimensions with --viewport-dimensions (default is 390x844).
+  -h, --help                                  display help for command
 ```
 
 ## HTML Output
@@ -68,4 +70,4 @@ npx aetest scan < example_inputs/component.html -c
 Once you've run a scan, the test results will be added to an HTML document at the file path specified in the output.
 Here is an example result:
 
-![Screenshot of a Testing SDK CLI report highlighting issues found on an example webpage. A table provides detailed information on issue type, WCAG level, WCAG number, and additional details.](/img/html-output-table.png)
+![Screenshot of an Accessibility Testing SDK CLI report highlighting issues found on an example webpage. A table provides detailed information on issue type, WCAG level, WCAG number, and additional details.](/img/html-output-table.png)

--- a/docs/cypress.mdx
+++ b/docs/cypress.mdx
@@ -1,18 +1,15 @@
 # Testing With Cypress
 
-The AudioEye Testing SDK Cypress Library gives you the ability to write Cypress tests to test for accessibility issues
-in your web application.
+The AudioEye Accessibility Testing SDK Cypress Library gives you the ability to write Cypress tests to test for
+accessibility issues in your web application.
 
 ## Pre-requisites
 
 Visit the [Getting Started](./get-started#cypress) page to learn how to setup Cypress in your project.
 
-**Note:** Our testing library uses [`cypress-promise`](https://www.npmjs.com/package/cypress-promise).
-
 ## Usage
 
-Import [`cypress-promise`](https://www.npmjs.com/package/cypress-promise) into your test file, visit the page you wish
-to test, and then use the [available tests](#available-tests) to test for accessibility issues.
+Use the [available tests](#available-tests) to test for accessibility issues in your Cypress tests.
 
 ```javascript
 describe('accessibility tests', () => {

--- a/docs/get-started.mdx
+++ b/docs/get-started.mdx
@@ -9,13 +9,14 @@ import TabItem from '@theme/TabItem';
 
 AudioEye's Accessibility Testing SDK is available as NPM packages (Node Package Manager)
 
+- [**Core**](#core) - @audioeye/testing-sdk-core
 - [**CLI**](#cli) - @audioeye/testing-sdk-cli
 - [**Jest**](#jest) - @audioeye/testing-sdk-jest
 - [**Cypress**](#cypress) - @audioeye/testing-sdk-cypress
 
 ## Software Requirements
 
-NPM version 16 or greater is required to use AudioEye Testing SDK
+NPM version 16 or greater is required to use AudioEye's Accessibility Testing SDK
 
 ## Pre-Requisites
 
@@ -34,7 +35,7 @@ you will need a copy of your AudioEye Entitlement Token. This token is available
 5. Once complete click on the _Copy Entitlement Token_ button to copy the key to your clipboard.
    ![Screenshot of a portion of the My Account page on the AudioEye Customer Portal. The screenshot shows the Testing SDK Entitlement Token card after successfully creating an entitlement token. A successful notification is shown, information about the token is listed, and two buttons are present. The first button has the label "Copy Entitlement Token" and the second is labeled "Refresh Entitlement Token"](/img/copy-entitlement-token.png)
 
-This key can now be used to download the AudioEye Testing SDK packages. We will refer to this key as
+This key can now be used to download the AudioEye Accessibility Testing SDK packages. We will refer to this key as
 `AUDIOEYE_ENTITLEMENT_TOKEN` in the rest of this document.
 
 ### Refreshing your entitlement token
@@ -65,6 +66,16 @@ contents:
 **Note:** For security reasons you should not commit the `AUDIOEYE_ENTITLEMENT_TOKEN` to your repository. Instead, you
 should set it up as a secret in GitHub and reference it in your workflow. Beta users will have this pre-generated with
 the `AUDIOEYE_ENTITLEMENT_TOKEN` filled out for them.
+
+## Core Package
+
+### NPM Installation or Update
+
+You can install or update the core package locally (as a developer only dependency) in your project.
+
+```bash
+npm install -D @audioeye/testing-sdk-core
+```
 
 ## CLI
 

--- a/docs/how-our-tests-work.mdx
+++ b/docs/how-our-tests-work.mdx
@@ -23,7 +23,7 @@ Full Test Results were output to testing-sdk/aetest_output.html
 
 You can easily find details about each of these failure details in the HTML output file. Here is an example result:
 
-![Screenshot of a Testing SDK CLI report highlighting issues found on an example webpage. A table provides detailed information on issue type, WCAG level, WCAG number, and additional details.](/img/html-output-table.png)
+![Screenshot of an Accessibility Testing SDK CLI report highlighting issues found on an example webpage. A table provides detailed information on issue type, WCAG level, WCAG number, and additional details.](/img/html-output-table.png)
 
 When a failure is returned, we will provide you the following information for all issues:
 

--- a/docs/jest.mdx
+++ b/docs/jest.mdx
@@ -1,6 +1,7 @@
 # Testing With Jest
 
-The AudioEye Testing SDK Jest Library gives you the ability to write Jest tests to test components of your project.
+The AudioEye Accessibility Testing SDK Jest Library gives you the ability to write Jest tests to test components of your
+project.
 
 ## Pre-requisites
 

--- a/docs/release-notes.mdx
+++ b/docs/release-notes.mdx
@@ -1,5 +1,11 @@
 # Release Notes
 
+## Version 1.2.0
+
+- Added new command line options to control the viewport size and turn on mobile emulation
+- Changed some of the command line options to be more consistent
+- Added documentation for calling the test function directly (not just through the CLI or Jest/Cypress)
+
 ## Version 1.1.3
 
 - Removed async/await from the [Jest](./jest) and [Cypress](./cypress) assertions

--- a/docs/writing-custom-tests.mdx
+++ b/docs/writing-custom-tests.mdx
@@ -1,1 +1,83 @@
 # Writing Custom Tests
+
+The AudioEye Accessibility Testing SDK allows you to write custom tests using the `@audioeye/testing-sdk-core` package.
+This package provides the core functionality used for all of our testing frameworks. If specific framework coverage is
+not provided, you can use this package to write your own tests.
+
+## Pre-requisites
+
+Visit the [Getting Started](../get-started#core-package) guide to install the SDK and set up your project.
+
+## Usage
+
+Use the `findIssues` function to run your custom tests. This function can be imported from
+`@audioeye/testing-sdk-core/testingTools`. The return type of this function is a `Result` provided by the
+[`ts-results`](https://www.npmjs.com/package/ts-results) package.
+
+### Importing the function
+
+```typescript
+import { findIssues } from '@audioeye/testing-sdk-core/testingTools';
+```
+
+### `findIssues` type signature
+
+```typescript
+import { Result } from 'ts-results';
+import type { RenderResult } from '@testing-library/react';
+
+export declare type EvaluateRulesInputType =
+  | string
+  | RenderResult
+  | HTMLElement
+  | DocumentFragment
+  | JQuery<HTMLElement>;
+
+declare type TestingSdkAllResultType = {
+  ruleResults: TestingSdkRuleResultType[];
+  exitCode: number;
+  summaryResults: string;
+  formattedResults: string;
+};
+
+declare type TestingSdkRuleResultType = {
+  ruleCode: string;
+  ruleMetadata: RuleMetaOutput | undefined;
+  result: FailResult;
+  source: string;
+};
+
+declare type RuleMetaOutput = {
+  code: string;
+  fullName: string;
+  description: string;
+  wcagSuccessCriteriaNumber: string;
+  wcagSuccessCriteriaName: string;
+  wcagSuccessCriteriaLevelCode: string;
+  sourceFixGuidance?: string;
+};
+
+export declare type FailResult = {
+  result: 'fail';
+};
+
+export declare const findIssues: (input: EvaluateRulesInputType) => Result<TestingSdkAllResultType, string>;
+```
+
+### Example
+
+```typescript
+import { findIssues } from '@audioeye/testing-sdk-core/testingTools';
+
+// `findIssues` takes a single argument of type `EvaluateRulesInputType`
+// This can be a string, a `RenderResult` object from `@testing-library/react`, an `HTMLElement`, a `DocumentFragment`, or a `JQuery<HTMLElement>`
+const result = findIssues(document.body);
+
+if (!result.ok) {
+  throw new Error(result.val);
+}
+
+const { ruleResults, exitCode, summaryResults, formattedResults } = result.val;
+
+// Handle the results
+```

--- a/sidebars.js
+++ b/sidebars.js
@@ -23,6 +23,7 @@ const sidebars = {
     'cli',
     'jest',
     'cypress',
+    'writing-custom-tests',
     'about_our_rules',
     'how-our-tests-work',
     'troubleshooting',

--- a/static/js/audioeye.js
+++ b/static/js/audioeye.js
@@ -4,7 +4,6 @@
     var a = document.createElement('script');
     a.src = 'https://wsmcdn.audioeye.com/aem.js';
     a.type = 'text/javascript';
-    a.setAttribute('async', '');
     document.getElementsByTagName('body')[0].appendChild(a);
   };
   'complete' !== document.readyState


### PR DESCRIPTION
### Internal Release Notes

the `async` option is removed when using springtime.